### PR TITLE
Fix Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ script:
 
   - julia --project --color=yes --check-bounds=yes -e 'using Pkg; Pkg.test(coverage=true);'
 
-  - julia --project=docs/ --color=yes 'docs/make.jl'
-
 after_success:
   # push coverage results to Codecov
   - julia -e 'import Pkg;
@@ -30,4 +28,3 @@ jobs:
                                                       Pkg.instantiate();
                                                       Pkg.build("Cloudy")'
         - julia --color=yes --project=docs/ docs/make.jl
-      after_success: skip


### PR DESCRIPTION
 - I think that the first call to building docs is somehow preventing the call to codecov (I think because it involves checking out the `gh-pages` branch, and maybe doesn't make it back)
 - That wasn't it, trying to remove `after_success: skip`