### PR TITLE
Rename all occurrences of "Distribution(s)" to "ParticleDistribution(s)"

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,7 +13,7 @@ makedocs(
   pages = Any[
     "Home" => "index.md",
     "KernelTensors" => "KernelTensors.md",
-    "MassDistributions" => "MassDistributions.md",
+    "ParticleDistributions" => "ParticleDistributions.md",
     "Sources" => "Sources.md"
   ]
 )

--- a/docs/src/ParticleDistributions.md
+++ b/docs/src/ParticleDistributions.md
@@ -1,15 +1,15 @@
-# Mass Distributions
+# Particle Distributions
 
 TODO
 
 ```@meta
-CurrentModule = Cloudy.MassDistributions
+CurrentModule = Cloudy.ParticleDistributions
 ```
 
 ## Functions
 
 ```@docs
-MassDistributionFunction
+ParticleDistribution
 Gamma
 Exponential
 compute_moment

--- a/examples/constant_kernel.jl
+++ b/examples/constant_kernel.jl
@@ -4,7 +4,7 @@ using DifferentialEquations
 using Plots
 
 using Cloudy.KernelTensors
-using Cloudy.Distributions
+using Cloudy.ParticleDistributions
 using Cloudy.Sources
 
 

--- a/examples/linear_kernel.jl
+++ b/examples/linear_kernel.jl
@@ -4,7 +4,7 @@ using DifferentialEquations
 using Plots
 
 using Cloudy.KernelTensors
-using Cloudy.Distributions
+using Cloudy.ParticleDistributions
 using Cloudy.Sources
 
 

--- a/examples/mixture_dist_linear_kernel.jl
+++ b/examples/mixture_dist_linear_kernel.jl
@@ -4,7 +4,7 @@ using DifferentialEquations
 using Plots
 
 using Cloudy.KernelTensors
-using Cloudy.Distributions
+using Cloudy.ParticleDistributions
 using Cloudy.Sources
 
 

--- a/examples/mixture_dist_product_kernel.jl
+++ b/examples/mixture_dist_product_kernel.jl
@@ -4,7 +4,7 @@ using DifferentialEquations
 using Plots
 
 using Cloudy.KernelTensors
-using Cloudy.Distributions
+using Cloudy.ParticleDistributions
 using Cloudy.Sources
 
 

--- a/examples/product_kernel.jl
+++ b/examples/product_kernel.jl
@@ -4,7 +4,7 @@ using DifferentialEquations
 using Plots
 
 using Cloudy.KernelTensors
-using Cloudy.Distributions
+using Cloudy.ParticleDistributions
 using Cloudy.Sources
 
 

--- a/examples/rainshaft.jl
+++ b/examples/rainshaft.jl
@@ -4,17 +4,17 @@ using DifferentialEquations
 using Plots
 
 using Cloudy.KernelTensors
-using Cloudy.Distributions
+using Cloudy.ParticleDistributions
 using Cloudy.Sources
 
-import Cloudy.Distributions: density, nparams
+import Cloudy.ParticleDistributions: density, nparams
 
 
 FT = Float64
 
 
 """
-  sedi_flux(mom_p::Array{Real}, dist::Distribution{Real}, vel::Array{Real})
+  sedi_flux(mom_p::Array{Real}, dist::ParticleDistribution{Real}, vel::Array{Real})
 
   - `mom_p` - prognostic moments of particle mass distribution
   - `dist` - particle mass distribution used to calculate diagnostic moments
@@ -22,7 +22,7 @@ FT = Float64
 Returns the sedimentation flux for all moments in `mom_p`.
 
 """
-function sedi_flux(mom_p::Array{FT}, dist::Distribution{FT}, coef::FT) where {FT <: Real}
+function sedi_flux(mom_p::Array{FT}, dist::ParticleDistribution{FT}, coef::FT) where {FT <: Real}
   s = length(mom_p)
   dist = update_params_from_moments(dist, mom_p)
    

--- a/src/Cloudy.jl
+++ b/src/Cloudy.jl
@@ -2,7 +2,7 @@ module Cloudy
 
 include("Kernels/KernelTensors.jl")
 include("Kernels/KernelFunctions.jl")
-include("Distributions/Distributions.jl")
+include("ParticleDistributions/ParticleDistributions.jl")
 include("Sources/Sources.jl")
 
 end

--- a/src/Sources/Sources.jl
+++ b/src/Sources/Sources.jl
@@ -9,7 +9,7 @@ Microphysics parameterization based on moment approximations:
 """
 module Sources
 
-using Cloudy.Distributions
+using Cloudy.ParticleDistributions
 using Cloudy.KernelTensors
 
 # methods that compute source terms from microphysical parameterizations
@@ -18,14 +18,14 @@ export get_flux_sedimentation
 
 
 """
-  get_int_coalescence(mom_p::Array{Real}, dist::Distribution{Real}, ker::KernelTensor{Real})
+  get_int_coalescence(mom_p::Array{Real}, dist::ParticleDistribution{Real}, ker::KernelTensor{Real})
 
   - `mom_p` - prognostic moments of particle mass distribution
   - `dist` - particle mass distribution used to calculate diagnostic moments
   - `ker` - coalescence kernel tensor
 Returns the coalescence integral for all moments in `mom_p`.
 """
-function get_int_coalescence(mom_p::Array{FT}, dist::Distribution{FT}, ker::KernelTensor{FT}) where {FT <: Real}
+function get_int_coalescence(mom_p::Array{FT}, dist::ParticleDistribution{FT}, ker::KernelTensor{FT}) where {FT <: Real}
   r = ker.r
   s = length(mom_p)
 
@@ -67,14 +67,14 @@ end
 
 
 """
-  get_flux_sedimentation(mom_p::Array{Real}, dist::Distribution{Real}, vel::Array{Real})
+  get_flux_sedimentation(mom_p::Array{Real}, dist::ParticleDistribution{Real}, vel::Array{Real})
 
   - `mom_p` - prognostic moments of particle mass distribution
   - `dist` - particle mass distribution used to calculate diagnostic moments
   _ `vel` - settling velocity coefficient tensor
 Returns the sedimentation flux for all moments in `mom_p`.
 """
-function get_flux_sedimentation(mom_p::Array{FT}, dist::Distribution{FT}, vel::Array{FT}) where {FT <: Real}
+function get_flux_sedimentation(mom_p::Array{FT}, dist::ParticleDistribution{FT}, vel::Array{FT}) where {FT <: Real}
   r = length(vel)-1
   s = length(mom_p) 
   

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,8 +10,8 @@ FT = Float64
       include("test_KernelFunctions_correctness.jl")
 	  end
 
-	  @testset "Distributions" begin
-	    include("test_Distributions_correctness.jl")
+	  @testset "ParticleDistributions" begin
+	    include("test_ParticleDistributions_correctness.jl")
     end
 
 	  @testset "Sources" begin

--- a/test/test_ParticleDistributions_correctness.jl
+++ b/test/test_ParticleDistributions_correctness.jl
@@ -1,9 +1,9 @@
-"Testing correctness of Distributions module."
+"Testing correctness of ParticleDistributions module."
 
 using SpecialFunctions: gamma, gamma_inc
-using Cloudy.Distributions
+using Cloudy.ParticleDistributions
 
-import Cloudy.Distributions: nparams, get_params, update_params,
+import Cloudy.ParticleDistributions: nparams, get_params, update_params,
                              check_moment_consistency, moment_func, density_func
 
 rtol = 1e-3
@@ -86,7 +86,7 @@ dist = update_params_from_moments(dist, [1.1, 2.423, 8.112])
 # Mixture distributions
 # Initialization
 dist = Mixture(Exponential(1.0, 1.0), Exponential(2.0, 2.0))
-@test typeof(dist.subdists) == Array{Distribution{FT}, 1}
+@test typeof(dist.subdists) == Array{ParticleDistribution{FT}, 1}
 @test length(dist.subdists) == 2
 
 # Getters and setters

--- a/test/test_Sources_correctness.jl
+++ b/test/test_Sources_correctness.jl
@@ -1,6 +1,6 @@
 "Testing correctness of Sources module."
 
-using Cloudy.Distributions
+using Cloudy.ParticleDistributions
 using Cloudy.Sources
 
 


### PR DESCRIPTION
Also includes @charleskawczynski's suggestion to change all input arguments 1.0 to FT(1) in file ParticleDistributions.jl.