### PR TITLE
Fix submodule reference, trim trailing spaces

### DIFF
--- a/examples/rainshaft.jl
+++ b/examples/rainshaft.jl
@@ -25,12 +25,12 @@ Returns the sedimentation flux for all moments in `mom_p`.
 function sedi_flux(mom_p::Array{FT}, dist::ParticleDistribution{FT}, coef::FT) where {FT <: Real}
   s = length(mom_p)
   dist = update_params_from_moments(dist, mom_p)
-   
+
   sedi_int = similar(mom_p)
   for k in 0:s-1
     sedi_int[k+1] = -coef*moment(dist, FT(k)+1/6)
   end
-  
+
   return sedi_int
 end
 
@@ -45,8 +45,8 @@ end
   - `n_z` - number of vertical levels
   - `mass_min` - minimum droplet mass
   - `mass_max` - maximum droplet mass
-  - `n_mass` - number of grid points in mass spass 
-Returns the results from a 1D rainshaft model run with collisions and sedimentation. 
+  - `n_mass` - number of grid points in mass spass
+Returns the results from a 1D rainshaft model run with collisions and sedimentation.
 
 """
 function main(t_min=0.0,
@@ -54,13 +54,13 @@ function main(t_min=0.0,
               z_min=0.0,
               z_max=1.0,
               n_z=50,
-              mass_min=0.0, 
+              mass_min=0.0,
               mass_max=10.0,
               n_mass=10)
-  
+
   # Physicsal parameters
   coal_kernel = CoalescenceTensor([0.01]) # constant coalescence kernel
-  sedi_coef = 0.2 # sedimentation flux coefficient 
+  sedi_coef = 0.2 # sedimentation flux coefficient
   distribution = Exponential(1.0, 1.0) # Size distribution function
 
   # Initial condition
@@ -101,8 +101,8 @@ function main(t_min=0.0,
       dm[i, :] += get_int_coalescence(m[i,:], distribution, coal_kernel)
     end
   end
-  
-  # Solve the ODE 
+
+  # Solve the ODE
   prob = ODEProblem(rhs!, moments_init, (t_min, t_max))
   sol = solve(prob)
 
@@ -138,14 +138,14 @@ end
   - `height` - height grid
   - `mass` - mass grid
   - `moments` - moments on time, height, mass grid
-  - `dists` - droplet mass distribution on time, height, mass grid 
+  - `dists` - droplet mass distribution on time, height, mass grid
 Generates various plots for the ODE solution.
 
 """
 function plotting(time, height, mass, moments, dists)
   gr()
   plot(
-    moments[1, :, 1], 
+    moments[1, :, 1],
     height,
     lw=3,
     xaxis="Number density",
@@ -156,15 +156,15 @@ function plotting(time, height, mass, moments, dists)
     title="Zeroth moment"
   )
   plot!(
-    moments[end, :, 1], 
-    height, 
+    moments[end, :, 1],
+    height,
     lw=3,
     label="Final condition"
   )
   savefig("zeroth_moment.png")
 
   plot(
-    moments[1, :, 2], 
+    moments[1, :, 2],
     height,
     lw=3,
     xaxis="Number density",
@@ -175,16 +175,16 @@ function plotting(time, height, mass, moments, dists)
     title="First moment"
   )
   plot!(
-    moments[end, :, 2], 
-    height, 
+    moments[end, :, 2],
+    height,
     lw=3,
     label="Final condition"
   )
   savefig("first_moment.png")
-  
+
   plot(
     time,
-    moments[:, 1, 1], 
+    moments[:, 1, 1],
     lw=3,
     xaxis="Time",
     yaxis="Moments",
@@ -195,7 +195,7 @@ function plotting(time, height, mass, moments, dists)
   )
   plot!(
     time,
-    moments[:, 1, 2], 
+    moments[:, 1, 2],
     lw=3,
     label="First moment"
   )

--- a/src/Cloudy.jl
+++ b/src/Cloudy.jl
@@ -1,8 +1,8 @@
 module Cloudy
 
-include("Kernels/KernelTensors.jl")
-include("Kernels/KernelFunctions.jl")
-include("ParticleDistributions/ParticleDistributions.jl")
-include("Sources/Sources.jl")
+include(joinpath("Kernels","KernelTensors.jl"))
+include(joinpath("Kernels","KernelFunctions.jl"))
+include(joinpath("ParticleDistributions","ParticleDistributions.jl"))
+include(joinpath("Sources","Sources.jl"))
 
 end

--- a/src/Kernels/KernelFunctions.jl
+++ b/src/Kernels/KernelFunctions.jl
@@ -9,8 +9,8 @@ export linear
 
 """
   linear(x::FT, y::FT)
-  
-  - `x` - array of particle masses 
+
+  - `x` - array of particle masses
 Return interaction rate based on particle masses.
 """
 function linear(x::Array{FT}) where {FT<:Real}

--- a/src/Kernels/KernelTensors.jl
+++ b/src/Kernels/KernelTensors.jl
@@ -61,19 +61,19 @@ end
 
   - `kernel_func` - is a collision-coalescence kernel function
   - `r` - is the order of the polynomial approximation
-  - `limit` - is the upper limit of particle mass allowed for this kernel function 
+  - `limit` - is the upper limit of particle mass allowed for this kernel function
 Returns a collision-coalescence rate matrix (as array) approximating the specified
 kernel function `kernel_func` to order `2r` using a monomial basis in two dimensions.
 """
 function polyfit(kernel_func, r::Int, limit::FT) where {FT<:Real}
-  check_symmetry(kernel_func) 
+  check_symmetry(kernel_func)
   # Build a coefficient matrix for the two-dimensional monomial
   # basis function set used for the polynomial approximation.
   Q = Array{FT}(undef, (r+1)^2, (r+1)^2)
   for i in 1:(r+1)^2
     for j in 1:(r+1)^2
-      a, b = unpack_vector_index_to_poly_index(i, r+1) 
-      c, d = unpack_vector_index_to_poly_index(j, r+1) 
+      a, b = unpack_vector_index_to_poly_index(i, r+1)
+      c, d = unpack_vector_index_to_poly_index(j, r+1)
       Q[i,j] = limit^(a+b+c+d+2) * (a+c+1.0)^(-1) * (b+d+1.0)^(-1)
     end
   end
@@ -82,23 +82,23 @@ function polyfit(kernel_func, r::Int, limit::FT) where {FT<:Real}
   # approximation problem (projects of kernel_func onto polynomial basis).
   F = Array{FT}(undef, (r+1)^2)
   for i in 1:(r+1)^2
-    a, b = unpack_vector_index_to_poly_index(i, r+1) 
+    a, b = unpack_vector_index_to_poly_index(i, r+1)
     integrand = x -> kernel_func(x) * x[1]^a * x[2]^b
-    F[i], err = hcubature(integrand, [0.0, 0.0], [limit, limit], rtol=1e-4, atol=1e-6) 
+    F[i], err = hcubature(integrand, [0.0, 0.0], [limit, limit], rtol=1e-4, atol=1e-6)
   end
 
   # Build vector of coefficients that measure importance of each monomial
   # in the polynomial approximation.
   K = inv(Q) * F
 
-  # Because polynomial regression was done in vector-matrix setup K is now a 
-  # one-dimensional array. The desired coefficient matrix corresponding to K 
+  # Because polynomial regression was done in vector-matrix setup K is now a
+  # one-dimensional array. The desired coefficient matrix corresponding to K
   # is just an unpacked version of K, where each entry of K is mapped onto a
   # matrix element.
   C = Array{FT}(undef, r+1, r+1)
   for (i, kk) in enumerate(K)
-    a, b = unpack_vector_index_to_poly_index(i, r+1) 
-    C[a+1, b+1] = K[i] 
+    a, b = unpack_vector_index_to_poly_index(i, r+1)
+    C[a+1, b+1] = K[i]
   end
 
   # Symmetrize collision-coalescence coefficient array to have numerically exact
@@ -112,8 +112,8 @@ end
 """
   unpack_vector_index_to_poly_index(ind::Int, array_size:Int)
 
-  - `ind` - vector index of vector that is being mapped to array 
-  - `array_size` - size of array the vector is being mapped to 
+  - `ind` - vector index of vector that is being mapped to array
+  - `array_size` - size of array the vector is being mapped to
 Returns the double index of a matrix that a vector is being mapped to.
 """
 function unpack_vector_index_to_poly_index(ind::Int, array_size::Int)
@@ -125,13 +125,13 @@ function unpack_vector_index_to_poly_index(ind::Int, array_size::Int)
   end
   i = ind
   r = array_size
-  div(i,r) + sign(mod(i,r)) - 1, mod(i,r) - sign(mod(ind,r)) * r + r - 1 
+  div(i,r) + sign(mod(i,r)) - 1, mod(i,r) - sign(mod(ind,r)) * r + r - 1
 end
 
 
 """
   symmetrize!(array::Array{FT})
-  - `array` - array that is being symmetrized 
+  - `array` - array that is being symmetrized
 """
 function symmetrize!(array::Array{FT}) where {FT<:Real}
   ndim = size(array)[1]
@@ -149,9 +149,9 @@ end
 """
   check_symmetry(array)
   check_symmetry(func)
-  
-  - `array` - array that is being checked for symmety 
-  - `func` - function that is being checked for symmety 
+
+  - `array` - array that is being checked for symmety
+  - `func` - function that is being checked for symmety
 Throws an exception if `array` is not symmetric.
 """
 function check_symmetry(array::Array{FT}) where {FT <: Real}

--- a/src/Sources/Sources.jl
+++ b/src/Sources/Sources.jl
@@ -9,8 +9,8 @@ Microphysics parameterization based on moment approximations:
 """
 module Sources
 
-using Cloudy.ParticleDistributions
-using Cloudy.KernelTensors
+using ..ParticleDistributions
+using ..KernelTensors
 
 # methods that compute source terms from microphysical parameterizations
 export get_int_coalescence
@@ -76,8 +76,8 @@ Returns the sedimentation flux for all moments in `mom_p`.
 """
 function get_flux_sedimentation(mom_p::Array{FT}, dist::ParticleDistribution{FT}, vel::Array{FT}) where {FT <: Real}
   r = length(vel)-1
-  s = length(mom_p) 
-  
+  s = length(mom_p)
+
   # Need to build diagnostic moments
   dist = update_params_from_moments(dist, mom_p)
   mom_d = Array{FT}(undef, r)


### PR DESCRIPTION
 - Replaces
```
using Cloudy.ParticleDistributions
using Cloudy.KernelTensors
```
with
```
using ..ParticleDistributions
using ..KernelTensors
```
This seems important since, if Cloudy is a registered package, and in your default environment, it's unclear to me whether `using Cloudy` will use the local dev package or one in the default environment. Therefore, `using ..ParticleDistributions` and `using ..KernelTensors` seems safer.

 - Adds `joinpath` to include submodules
 - Trims trailing spaces