### PR TITLE
 Make ParticleDistribution structs immutable 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 env:
   OPENBLAS_NUM_THREADS: 1
+  JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/default"
 
 agents:
   queue: new-central

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7.2'
+          - '1.10'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/docs/src/ParticleDistributions.md
+++ b/docs/src/ParticleDistributions.md
@@ -14,6 +14,6 @@ get_moments
 density
 normed_density
 nparams
-update_dist_from_moments!
+update_dist_from_moments
 moment_source_helper
 ```

--- a/src/ParticleDistributions/ParticleDistributions.jl
+++ b/src/ParticleDistributions/ParticleDistributions.jl
@@ -215,12 +215,12 @@ function moment(dist::AbstractParticleDistribution{FT}, q::FT) where {FT <: Real
     moment_func(dist)(q)
 end
 
+# TODO: Move to examples
 """
     get_moments(pdist::GammaParticleDistribution{FT})
 Returns the first P (0, 1, 2) moments of the distribution where P is the innate
 numer of prognostic moments
 """
-# TODO: Move to examples
 function get_moments(pdist::GammaPrimitiveParticleDistribution{FT}) where {FT <: Real}
     return [pdist.n, pdist.n * pdist.k * pdist.θ, pdist.n * pdist.k * (pdist.k + 1) * pdist.θ^2]
 end

--- a/src/ParticleDistributions/ParticleDistributions.jl
+++ b/src/ParticleDistributions/ParticleDistributions.jl
@@ -395,15 +395,15 @@ Returns a new gamma distribution given the first three moments
 function update_dist_from_moments(
     pdist::GammaPrimitiveParticleDistribution{FT},
     moments::Array{FT};
-    param_range = Dict("θ" => (eps(FT), Inf), "k" => (eps(FT), Inf)),
+    param_range = (; :θ => (eps(FT), Inf), :k => (eps(FT), Inf)),
 ) where {FT <: Real}
     @assert length(moments) == 3
     if moments[1] > eps(FT) && moments[2] > eps(FT) && moments[3] > eps(FT)
         k = max(
-            param_range["k"][1],
-            min(param_range["k"][2], (moments[2] / moments[1]) / (moments[3] / moments[2] - moments[2] / moments[1])),
+            param_range.k[1],
+            min(param_range.k[2], (moments[2] / moments[1]) / (moments[3] / moments[2] - moments[2] / moments[1])),
         )
-        θ = max(param_range["θ"][1], min(param_range["θ"][2], moments[3] / moments[2] - moments[2] / moments[1]))
+        θ = max(param_range.θ[1], min(param_range.θ[2], moments[3] / moments[2] - moments[2] / moments[1]))
         n = moments[2] / (k * θ)
         return GammaPrimitiveParticleDistribution(n, θ, k)
     else #don't change θ and k
@@ -419,15 +419,15 @@ Returns a new lognormal distribution given the first three moments
 function update_dist_from_moments(
     pdist::LognormalPrimitiveParticleDistribution{FT},
     moments::Array{FT};
-    param_range = Dict("μ" => (-Inf, Inf), "σ" => (eps(FT), Inf)),
+    param_range = (; :μ => (-Inf, Inf), :σ => (eps(FT), Inf)),
 ) where {FT <: Real}
     @assert length(moments) == 3
     if moments[1] > eps(FT) && moments[2] > eps(FT) && moments[3] > eps(FT)
         μ = max(
-            param_range["μ"][1],
-            min(param_range["μ"][2], log(moments[2]^2 / moments[1]^(3 / 2) / moments[3]^(1 / 2))),
+            param_range.μ[1],
+            min(param_range.μ[2], log(moments[2]^2 / moments[1]^(3 / 2) / moments[3]^(1 / 2))),
         )
-        σ = max(param_range["σ"][1], min(param_range["σ"][2], sqrt(log(moments[1] * moments[3] / moments[2]^2))))
+        σ = max(param_range.σ[1], min(param_range.σ[2], sqrt(log(moments[1] * moments[3] / moments[2]^2))))
         n = moments[2] / exp(μ + 1 / 2 * σ^2)
         return LognormalPrimitiveParticleDistribution(n, μ, σ)
     else #don't change μ and σ
@@ -443,11 +443,11 @@ Returns a new exponential distribution given the first two moments
 function update_dist_from_moments(
     pdist::ExponentialPrimitiveParticleDistribution{FT},
     moments::Array{FT};
-    param_range = Dict("θ" => (eps(FT), Inf)),
+    param_range = (; :θ => (eps(FT), Inf)),
 ) where {FT <: Real}
     @assert length(moments) == 2
     if moments[1] > eps(FT) && moments[2] > eps(FT)
-        θ = max(param_range["θ"][1], min(param_range["θ"][2], moments[2] / moments[1]))
+        θ = max(param_range.θ[1], min(param_range.θ[2], moments[2] / moments[1]))
         n = moments[2] / θ
         return ExponentialPrimitiveParticleDistribution(n, θ)
     else #don't change θ
@@ -463,11 +463,11 @@ Returns a new monodisperse distribution given the first two moments
 function update_dist_from_moments(
     pdist::MonodispersePrimitiveParticleDistribution{FT},
     moments::Array{FT};
-    param_range = Dict("θ" => (eps(FT), Inf)),
+    param_range = (; :θ => (eps(FT), Inf)),
 ) where {FT <: Real}
     @assert length(moments) == 2
     if moments[1] > eps(FT) && moments[2] > eps(FT)
-        θ = max(param_range["θ"][1], min(param_range["θ"][2], moments[2] / moments[1]))
+        θ = max(param_range.θ[1], min(param_range.θ[2], moments[2] / moments[1]))
         n = moments[2] / θ
         return MonodispersePrimitiveParticleDistribution(n, θ)
     else #don't change θ

--- a/src/ParticleDistributions/ParticleDistributions.jl
+++ b/src/ParticleDistributions/ParticleDistributions.jl
@@ -27,7 +27,7 @@ export get_moments
 export density
 export normed_density
 export nparams
-export update_dist_from_moments!
+export update_dist_from_moments
 export moment_source_helper
 export get_standard_N_q
 
@@ -64,7 +64,7 @@ Represents particle mass distribution function of exponential shape.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-mutable struct ExponentialPrimitiveParticleDistribution{FT} <: PrimitiveParticleDistribution{FT}
+struct ExponentialPrimitiveParticleDistribution{FT} <: PrimitiveParticleDistribution{FT}
     "normalization constant (e.g., droplet number concentration)"
     n::FT
     "scale parameter"
@@ -91,7 +91,7 @@ Represents particle mass distribution function of gamma shape.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-mutable struct GammaPrimitiveParticleDistribution{FT} <: PrimitiveParticleDistribution{FT}
+struct GammaPrimitiveParticleDistribution{FT} <: PrimitiveParticleDistribution{FT}
     "normalization constant (e.g., droplet number concentration)"
     n::FT
     "scale parameter"
@@ -118,7 +118,7 @@ Represents monodisperse particle size distribution function.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-mutable struct MonodispersePrimitiveParticleDistribution{FT} <: PrimitiveParticleDistribution{FT}
+struct MonodispersePrimitiveParticleDistribution{FT} <: PrimitiveParticleDistribution{FT}
     "normalization constant (e.g., droplet number concentration)"
     n::FT
     "particle diameter"
@@ -143,7 +143,7 @@ Represents lognormal particle size distribution function.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-mutable struct LognormalPrimitiveParticleDistribution{FT} <: PrimitiveParticleDistribution{FT}
+struct LognormalPrimitiveParticleDistribution{FT} <: PrimitiveParticleDistribution{FT}
     "normalization constant (e.g., droplet number concentration)"
     n::FT
     "logarithmic mean size"
@@ -388,86 +388,90 @@ function check_moment_consistency(m::Array{FT}) where {FT <: Real}
 end
 
 """
-    update_dist_from_moments!(pdist::GammaPrimitiveParticleDistribution{FT}, moments::Array{FT})
+    update_dist_from_moments(pdist::GammaPrimitiveParticleDistribution{FT}, moments::Array{FT})
 
-Updates parameters of the gamma distribution given the first three moments
+Returns a new gamma distribution given the first three moments
 """
-function update_dist_from_moments!(
+function update_dist_from_moments(
     pdist::GammaPrimitiveParticleDistribution{FT},
     moments::Array{FT};
     param_range = Dict("θ" => (eps(FT), Inf), "k" => (eps(FT), Inf)),
 ) where {FT <: Real}
     @assert length(moments) == 3
     if moments[1] > eps(FT) && moments[2] > eps(FT) && moments[3] > eps(FT)
-        pdist.k = max(
+        k = max(
             param_range["k"][1],
             min(param_range["k"][2], (moments[2] / moments[1]) / (moments[3] / moments[2] - moments[2] / moments[1])),
         )
-        pdist.θ = max(param_range["θ"][1], min(param_range["θ"][2], moments[3] / moments[2] - moments[2] / moments[1]))
-        pdist.n = moments[2] / (pdist.k * pdist.θ)
+        θ = max(param_range["θ"][1], min(param_range["θ"][2], moments[3] / moments[2] - moments[2] / moments[1]))
+        n = moments[2] / (k * θ)
+        return GammaPrimitiveParticleDistribution(n, θ, k)
     else #don't change θ and k
-        pdist.n = FT(0)
+        GammaPrimitiveParticleDistribution(FT(0), pdist.θ, pdist.k)
     end
 end
 
 """
-    update_dist_from_moments!(pdist::LognormalPrimitiveParticleDistribution{FT}, moments::Array{FT})
+    update_dist_from_moments(pdist::LognormalPrimitiveParticleDistribution{FT}, moments::Array{FT})
 
-Updates parameters of the lognormal distribution given the first three moments
+Returns a new lognormal distribution given the first three moments
 """
-function update_dist_from_moments!(
+function update_dist_from_moments(
     pdist::LognormalPrimitiveParticleDistribution{FT},
     moments::Array{FT};
     param_range = Dict("μ" => (-Inf, Inf), "σ" => (eps(FT), Inf)),
 ) where {FT <: Real}
     @assert length(moments) == 3
     if moments[1] > eps(FT) && moments[2] > eps(FT) && moments[3] > eps(FT)
-        pdist.μ = max(
+        μ = max(
             param_range["μ"][1],
             min(param_range["μ"][2], log(moments[2]^2 / moments[1]^(3 / 2) / moments[3]^(1 / 2))),
         )
-        pdist.σ = max(param_range["σ"][1], min(param_range["σ"][2], sqrt(log(moments[1] * moments[3] / moments[2]^2))))
-        pdist.n = moments[2] / exp(pdist.μ + 1 / 2 * pdist.σ^2)
+        σ = max(param_range["σ"][1], min(param_range["σ"][2], sqrt(log(moments[1] * moments[3] / moments[2]^2))))
+        n = moments[2] / exp(μ + 1 / 2 * σ^2)
+        return LognormalPrimitiveParticleDistribution(n, μ, σ)
     else #don't change μ and σ
-        pdist.n = FT(0)
+        return LognormalPrimitiveParticleDistribution(FT(0), pdist.μ, pdist.σ)
     end
 end
 
 """
-    update_dist_from_moments!(pdist::ExponentialPrimitiveParticleDistribution{FT}, moments::Array{FT})
+    update_dist_from_moments(pdist::ExponentialPrimitiveParticleDistribution{FT}, moments::Array{FT})
 
-Updates parameters of the exponential distribution given the first two moments
+Returns a new exponential distribution given the first two moments
 """
-function update_dist_from_moments!(
+function update_dist_from_moments(
     pdist::ExponentialPrimitiveParticleDistribution{FT},
     moments::Array{FT};
     param_range = Dict("θ" => (eps(FT), Inf)),
 ) where {FT <: Real}
     @assert length(moments) == 2
     if moments[1] > eps(FT) && moments[2] > eps(FT)
-        pdist.θ = max(param_range["θ"][1], min(param_range["θ"][2], moments[2] / moments[1]))
-        pdist.n = moments[2] / pdist.θ
+        θ = max(param_range["θ"][1], min(param_range["θ"][2], moments[2] / moments[1]))
+        n = moments[2] / θ
+        return ExponentialPrimitiveParticleDistribution(n, θ)
     else #don't change θ
-        pdist.n = FT(0)
+        return ExponentialPrimitiveParticleDistribution(FT(0), pdist.θ)
     end
 end
 
 """
-    update_dist_from_moments!(pdist::MonodispersePrimitiveParticleDistribution{FT}, moments::Array{FT})
+    update_dist_from_moments(pdist::MonodispersePrimitiveParticleDistribution{FT}, moments::Array{FT})
 
-Updates parameters of the monodisperse distribution given the first two moments
+Returns a new monodisperse distribution given the first two moments
 """
-function update_dist_from_moments!(
+function update_dist_from_moments(
     pdist::MonodispersePrimitiveParticleDistribution{FT},
     moments::Array{FT};
     param_range = Dict("θ" => (eps(FT), Inf)),
 ) where {FT <: Real}
     @assert length(moments) == 2
     if moments[1] > eps(FT) && moments[2] > eps(FT)
-        pdist.θ = max(param_range["θ"][1], min(param_range["θ"][2], moments[2] / moments[1]))
-        pdist.n = moments[2] / pdist.θ
+        θ = max(param_range["θ"][1], min(param_range["θ"][2], moments[2] / moments[1]))
+        n = moments[2] / θ
+        return MonodispersePrimitiveParticleDistribution(n, θ)
     else #don't change θ
-        pdist.n = FT(0)
+        return MonodispersePrimitiveParticleDistribution(FT(0), pdist.θ)
     end
 end
 

--- a/src/ParticleDistributions/ParticleDistributions.jl
+++ b/src/ParticleDistributions/ParticleDistributions.jl
@@ -423,10 +423,7 @@ function update_dist_from_moments(
 ) where {FT <: Real}
     @assert length(moments) == 3
     if moments[1] > eps(FT) && moments[2] > eps(FT) && moments[3] > eps(FT)
-        μ = max(
-            param_range.μ[1],
-            min(param_range.μ[2], log(moments[2]^2 / moments[1]^(3 / 2) / moments[3]^(1 / 2))),
-        )
+        μ = max(param_range.μ[1], min(param_range.μ[2], log(moments[2]^2 / moments[1]^(3 / 2) / moments[3]^(1 / 2))))
         σ = max(param_range.σ[1], min(param_range.σ[2], sqrt(log(moments[1] * moments[3] / moments[2]^2))))
         n = moments[2] / exp(μ + 1 / 2 * σ^2)
         return LognormalPrimitiveParticleDistribution(n, μ, σ)

--- a/src/ParticleDistributions/ParticleDistributions.jl
+++ b/src/ParticleDistributions/ParticleDistributions.jl
@@ -460,7 +460,7 @@ Returns a new monodisperse distribution given the first two moments
 function update_dist_from_moments(
     pdist::MonodispersePrimitiveParticleDistribution{FT},
     moments::Array{FT};
-    param_range = (; :θ => (eps(FT), Inf)),
+    param_range::NamedTuple = (; :θ => (eps(FT), Inf)),
 ) where {FT <: Real}
     @assert length(moments) == 2
     if moments[1] > eps(FT) && moments[2] > eps(FT)

--- a/src/ParticleDistributions/ParticleDistributions.jl
+++ b/src/ParticleDistributions/ParticleDistributions.jl
@@ -175,7 +175,7 @@ Returns a function that computes the moments of `dist`.
 function moment_func(dist::ExponentialPrimitiveParticleDistribution{FT}) where {FT <: Real}
     # moment_of_dist = n * θ^q * Γ(q+1)
     function f(q)
-        dist.n * dist.θ ^ q * gamma(q + FT(1))
+        dist.n * dist.θ^q * gamma(q + FT(1))
     end
     return f
 end
@@ -183,7 +183,7 @@ end
 function moment_func(dist::GammaPrimitiveParticleDistribution{FT}) where {FT <: Real}
     # moment_of_dist = n * θ^q * Γ(q+k) / Γ(k)
     function f(q)
-        dist.n * dist.θ ^ q * gamma(q + dist.k) / gamma(dist.k)
+        dist.n * dist.θ^q * gamma(q + dist.k) / gamma(dist.k)
     end
     return f
 end
@@ -191,7 +191,7 @@ end
 function moment_func(dist::MonodispersePrimitiveParticleDistribution{FT}) where {FT <: Real}
     # moment_of_dist = n * θ^(q)
     function f(q)
-        dist.n * dist.θ ^ q
+        dist.n * dist.θ^q
     end
     return f
 end
@@ -199,7 +199,7 @@ end
 function moment_func(dist::LognormalPrimitiveParticleDistribution{FT}) where {FT <: Real}
     # moment_of_dist = n * exp(q * μ + 1/2 * q^2 * σ^2)
     function f(q)
-        dist.n * exp(q * dist.μ + q ^ 2 * dist.σ ^ 2 / 2)
+        dist.n * exp(q * dist.μ + q^2 * dist.σ^2 / 2)
     end
     return f
 end
@@ -344,45 +344,37 @@ function nparams(dist::PrimitiveParticleDistribution{FT}) where {FT <: Real}
 end
 
 """
-  check_moment_consistency(m::Array{FT})
+  check_moment_consistency(m::NTuple{N, T})
 
   - `m` - is an array of moments
 
 Checks if moments are nonnegative and whether even-ordered central moments implied
 by moments vector are all positive.
 """
-function check_moment_consistency(m::Array{FT}) where {FT <: Real}
-    n_mom = length(m)
+function check_moment_consistency(m::NTuple{N, FT}) where {N, FT <: Real}
     # check if  moments are nonnegative
-    if any(m .< 0.0)
-        error("all moments need to be nonnegative.")
-    end
+    any(m .< 0.0) && error("all moments need to be nonnegative.")
 
     # check if even-ordered central moments are positive (e.g., variance, etc.)
     # non-positivity  would be inconsistent with a well-defined distribution.
-    for order in 2:2:(n_mom - 1)
-        cm = 0.0
-        for i in 0:order
-            cm += binomial(order, i) * (-1)^i * (m[2] / m[1])^i * (m[order - i + 1] / m[1])
+    for order in 2:2:(length(m) - 1)
+        cm = mapreduce(+, 0:order) do i
+            binomial(order, i) * (-1)^i * (m[2] / m[1])^i * (m[order - i + 1] / m[1])
         end
-        if cm < 0.0
-            error("order-$order central moment needs to be nonnegative.")
-        end
+        cm < 0.0 && error("order central moment needs to be nonnegative.")
     end
-
 end
 
 """
-    update_dist_from_moments(pdist::GammaPrimitiveParticleDistribution{FT}, moments::Array{FT})
+    update_dist_from_moments(pdist::GammaPrimitiveParticleDistribution{FT}, moments::Tuple{FT, FT, FT})
 
 Returns a new gamma distribution given the first three moments
 """
 function update_dist_from_moments(
     pdist::GammaPrimitiveParticleDistribution{FT},
-    moments::Array{FT};
+    moments::Tuple{FT, FT, FT};
     param_range = (; :θ => (eps(FT), Inf), :k => (eps(FT), Inf)),
 ) where {FT <: Real}
-    @assert length(moments) == 3
     if moments[1] > eps(FT) && moments[2] > eps(FT) && moments[3] > eps(FT)
         k = max(
             param_range.k[1],
@@ -397,16 +389,15 @@ function update_dist_from_moments(
 end
 
 """
-    update_dist_from_moments(pdist::LognormalPrimitiveParticleDistribution{FT}, moments::Array{FT})
+    update_dist_from_moments(pdist::LognormalPrimitiveParticleDistribution{FT}, moments::Tuple{FT, FT})
 
 Returns a new lognormal distribution given the first three moments
 """
 function update_dist_from_moments(
     pdist::LognormalPrimitiveParticleDistribution{FT},
-    moments::Array{FT};
+    moments::Tuple{FT, FT, FT};
     param_range = (; :μ => (-Inf, Inf), :σ => (eps(FT), Inf)),
 ) where {FT <: Real}
-    @assert length(moments) == 3
     if moments[1] > eps(FT) && moments[2] > eps(FT) && moments[3] > eps(FT)
         μ = max(param_range.μ[1], min(param_range.μ[2], log(moments[2]^2 / moments[1]^(3 / 2) / moments[3]^(1 / 2))))
         σ = max(param_range.σ[1], min(param_range.σ[2], sqrt(log(moments[1] * moments[3] / moments[2]^2))))
@@ -418,16 +409,15 @@ function update_dist_from_moments(
 end
 
 """
-    update_dist_from_moments(pdist::ExponentialPrimitiveParticleDistribution{FT}, moments::Array{FT})
+    update_dist_from_moments(pdist::ExponentialPrimitiveParticleDistribution{FT}, moments::Tuple{FT, FT})
 
 Returns a new exponential distribution given the first two moments
 """
 function update_dist_from_moments(
     pdist::ExponentialPrimitiveParticleDistribution{FT},
-    moments::Array{FT};
+    moments::Tuple{FT, FT};
     param_range = (; :θ => (eps(FT), Inf)),
 ) where {FT <: Real}
-    @assert length(moments) == 2
     if moments[1] > eps(FT) && moments[2] > eps(FT)
         θ = max(param_range.θ[1], min(param_range.θ[2], moments[2] / moments[1]))
         n = moments[2] / θ
@@ -438,16 +428,15 @@ function update_dist_from_moments(
 end
 
 """
-    update_dist_from_moments(pdist::MonodispersePrimitiveParticleDistribution{FT}, moments::Array{FT})
+    update_dist_from_moments(pdist::MonodispersePrimitiveParticleDistribution{FT}, moments::Tuple{FT, FT})
 
 Returns a new monodisperse distribution given the first two moments
 """
 function update_dist_from_moments(
     pdist::MonodispersePrimitiveParticleDistribution{FT},
-    moments::Array{FT};
+    moments::Tuple{FT, FT};
     param_range::NamedTuple = (; :θ => (eps(FT), Inf)),
 ) where {FT <: Real}
-    @assert length(moments) == 2
     if moments[1] > eps(FT) && moments[2] > eps(FT)
         θ = max(param_range.θ[1], min(param_range.θ[2], moments[2] / moments[1]))
         n = moments[2] / θ
@@ -477,9 +466,7 @@ function moment_source_helper(
     p2::FT,
     x_threshold::FT,
 ) where {FT <: Real}
-    (; n, θ) = dist
-    source = (θ < x_threshold / 2) ? n^2 * θ^(p1 + p2) : FT(0)
-    return source
+    return (dist.θ < x_threshold / 2) ? dist.n^2 * dist.θ^(p1 + p2) : FT(0)
 end
 
 function moment_source_helper(
@@ -542,20 +529,16 @@ end
 Returns a named tuple (N_liq, N_rai, M_liq, M_rai) of the number and mass densities of liquid (cloud) and rain computed
 from the current pdists given a size cutoff
 """
-function get_standard_N_q(pdists; size_cutoff = 1, rtol = 1e-8)
-    FT = typeof(pdists[1].n)
-    N_liq = FT(0)
-    N_rai = FT(0)
-    M_liq = FT(0)
-    M_rai = FT(0)
-
+function get_standard_N_q(
+    pdists::NTuple{N, PrimitiveParticleDistribution{FT}};
+    size_cutoff = 1,
+    rtol = 1e-8,
+) where {FT, N}
     Ndist = length(pdists)
-    for j in 1:Ndist
-        N_liq = N_liq + quadgk(x -> pdists[j](x), FT(0.0), FT(size_cutoff); rtol = FT(rtol))[1]
-        M_liq = M_liq + quadgk(x -> x * pdists[j](x), FT(0.0), FT(size_cutoff); rtol = FT(rtol))[1]
-        N_rai = N_rai + quadgk(x -> pdists[j](x), FT(size_cutoff), Inf; rtol = FT(rtol))[1]
-        M_rai = M_rai + quadgk(x -> x * pdists[j](x), FT(size_cutoff), Inf; rtol = FT(rtol))[1]
-    end
+    N_liq = mapreduce(j -> quadgk(x -> pdists[j](x), FT(0.0), FT(size_cutoff); rtol = FT(rtol))[1], +, 1:Ndist)
+    M_liq = mapreduce(j -> quadgk(x -> x * pdists[j](x), FT(0.0), FT(size_cutoff); rtol = FT(rtol))[1], +, 1:Ndist)
+    N_rai = mapreduce(j -> quadgk(x -> pdists[j](x), FT(size_cutoff), Inf; rtol = FT(rtol))[1], +, 1:Ndist)
+    M_rai = mapreduce(j -> quadgk(x -> x * pdists[j](x), FT(size_cutoff), Inf; rtol = FT(rtol))[1], +, 1:Ndist)
 
     return (; N_liq, N_rai, M_liq, M_rai)
 end

--- a/src/Sources/Sedimentation.jl
+++ b/src/Sources/Sedimentation.jl
@@ -23,7 +23,7 @@ function get_sedimentation_flux(pdists, vel)
     n_dist = length(pdists)
     n_params = [nparams(dist) for dist in pdists]
     n_vel = length(vel)
-    FT = eltype(get_params(pdists[1])[2])
+    FT = typeof(pdists[1].n)
 
     # Need to build diagnostic moments
     mom = [zeros(n, n_vel) for n in n_params]

--- a/test/examples/Analytical/box_single_gamma.jl
+++ b/test/examples/Analytical/box_single_gamma.jl
@@ -1,6 +1,6 @@
 "Box model with a single gamma mode"
 
-import Cloudy 
+import Cloudy
 using DifferentialEquations
 
 include(joinpath(pkgdir(Cloudy), "test", "examples", "utils", "box_model_helpers.jl"))

--- a/test/examples/Analytical/box_single_gamma.jl
+++ b/test/examples/Analytical/box_single_gamma.jl
@@ -1,9 +1,10 @@
 "Box model with a single gamma mode"
 
+import Cloudy 
 using DifferentialEquations
 
-include("../utils/box_model_helpers.jl")
-include("../utils/plotting_helpers.jl")
+include(joinpath(pkgdir(Cloudy), "test", "examples", "utils", "box_model_helpers.jl"))
+include(joinpath(pkgdir(Cloudy), "test", "examples", "utils", "plotting_helpers.jl"))
 
 FT = Float64
 

--- a/test/examples/utils/box_model_helpers.jl
+++ b/test/examples/utils/box_model_helpers.jl
@@ -27,7 +27,7 @@ function rhs_coal!(coal_type::CoalescenceStyle, dmom, mom, p)
     mom_normalized = mom ./ mom_norms
     for (i, dist) in enumerate(p.pdists)
         ind_rng = get_dist_moments_ind_range(p.NProgMoms, i)
-        update_dist_from_moments!(dist, mom_normalized[ind_rng])
+        dist = update_dist_from_moments(dist, mom_normalized[ind_rng])
     end
     update_coal_ints!(coal_type, p.pdists, p.coal_data)
     dmom .= p.coal_data.coal_ints .* mom_norms
@@ -38,7 +38,7 @@ function rhs_condensation!(dmom, mom, p, s)
     mom_normalized = mom ./ mom_norms
     for (i, dist) in enumerate(p.pdists)
         ind_rng = get_dist_moments_ind_range(p.NProgMoms, i)
-        update_dist_from_moments!(dist, mom_normalized[ind_rng])
+        dist = update_dist_from_moments(dist, mom_normalized[ind_rng])
     end
     dmom .= get_cond_evap(s, p) .* mom_norms
 end

--- a/test/examples/utils/box_model_helpers.jl
+++ b/test/examples/utils/box_model_helpers.jl
@@ -35,7 +35,7 @@ end
 
 function rhs_condensation!(dmom, mom, p, s)
     mom_norms = get_moments_normalizing_factors(p.NProgMoms, p.norms)
-    mom_normalized = mom ./ mom_norms
+    mom_normalized = tuple(mom ./ mom_norms...)
     for (i, dist) in enumerate(p.pdists)
         ind_rng = get_dist_moments_ind_range(p.NProgMoms, i)
         dist = update_dist_from_moments(dist, mom_normalized[ind_rng])

--- a/test/examples/utils/box_model_helpers.jl
+++ b/test/examples/utils/box_model_helpers.jl
@@ -24,7 +24,7 @@ end
 
 function rhs_coal!(coal_type::CoalescenceStyle, dmom, mom, p)
     mom_norms = get_moments_normalizing_factors(p.NProgMoms, p.norms)
-    mom_normalized = mom ./ mom_norms
+    mom_normalized = tuple(mom ./ mom_norms...)
     for (i, dist) in enumerate(p.pdists)
         ind_rng = get_dist_moments_ind_range(p.NProgMoms, i)
         dist = update_dist_from_moments(dist, mom_normalized[ind_rng])

--- a/test/examples/utils/plotting_helpers.jl
+++ b/test/examples/utils/plotting_helpers.jl
@@ -115,7 +115,8 @@ function plot_spectra!(sol, p; file_name = "test_spectra.png", logxrange = (-15,
         plt[i] = plot()
         for j in 1:Ndist
             ind_rng = get_dist_moments_ind_range(p.NProgMoms, j)
-            update_dist_from_moments(p.pdists[j], moments[t_ind[i], ind_rng])
+            moment_tuple = tuple(moments[t_ind[i], ind_rng]...)
+            update_dist_from_moments(p.pdists[j], moment_tuple)
             plot!(
                 r,
                 3 * x .^ 2 .* p.pdists[j].(x),
@@ -161,14 +162,14 @@ function plot_params!(sol, p; yscale = :log10, file_name = "box_model.pdf")
     mom_norms = get_moments_normalizing_factors(p.NProgMoms, p.norms)
     moments = vcat(sol.u'...) ./ mom_norms'
     params = similar(moments)
-
     n_dist = length(p.pdists)
     plt = Array{Plots.Plot}(undef, n_dist)
     n_params = [nparams(p.pdists[i]) for i in 1:n_dist]
     for i in 1:n_dist
         ind_rng = get_dist_moments_ind_range(p.NProgMoms, i)
         for j in 1:size(params)[1]
-            p.pdists[i] = CPD.update_dist_from_moments(p.pdists[i], moments[j, ind_rng])
+            moment_tuple = tuple(moments[j, ind_rng]...)
+            p.pdists[i] = CPD.update_dist_from_moments(p.pdists[i], moment_tuple)
             params[j, ind_rng] = vcat(get_params(p.pdists[i])[2]...)
         end
 
@@ -230,7 +231,8 @@ function print_box_results!(sol, p)
     for i in 1:3
         for j in 1:Ndist
             ind_rng = get_dist_moments_ind_range(p.NProgMoms, j)
-            p.pdists[j] = update_dist_from_moments(p.pdists[j], moments[t_ind[i], ind_rng])
+            moment_tuple = tuple(moments[t_ind[i], ind_rng]...)
+            p.pdists[j] = update_dist_from_moments(p.pdists[j], moment_tuple)
             params[i, j, 1:p.NProgMoms[j]] = vcat(get_params(p.pdists[j])[2]...)
         end
     end

--- a/test/examples/utils/plotting_helpers.jl
+++ b/test/examples/utils/plotting_helpers.jl
@@ -3,6 +3,19 @@ using Plots
 include("./box_model_helpers.jl")
 include("./rainshaft_helpers.jl")
 
+
+"""
+  get_params(dist)
+
+  - `dist` - is a particle mass distribution
+Returns the names and values of settable parameters for a dist.
+"""
+function get_params(dist::CPD.PrimitiveParticleDistribution{FT <: Real})
+    params = Array{Symbol, 1}(collect(propertynames(dist)))
+    values = Array{FT, 1}([getproperty(dist, p) for p in params])
+    return params, values
+end
+
 """
   plot_moments(sol, p; file_name = "test_moments.png")
 
@@ -156,7 +169,7 @@ function plot_params!(sol, p; yscale = :log10, file_name = "box_model.pdf")
         ind_rng = get_dist_moments_ind_range(p.NProgMoms, i)
         for j in 1:size(params)[1]
             p.pdists[i] = CPD.update_dist_from_moments(p.pdists[i], moments[j, ind_rng])
-            params[j, ind_rng] = vcat(CPD.get_params(p.pdists[i])[2]...)
+            params[j, ind_rng] = vcat(get_params(p.pdists[i])[2]...)
         end
 
         plot()
@@ -218,7 +231,7 @@ function print_box_results!(sol, p)
         for j in 1:Ndist
             ind_rng = get_dist_moments_ind_range(p.NProgMoms, j)
             p.pdists[j] = update_dist_from_moments(p.pdists[j], moments[t_ind[i], ind_rng])
-            params[i, j, 1:p.NProgMoms[j]] = vcat(CPD.get_params(p.pdists[j])[2]...)
+            params[i, j, 1:p.NProgMoms[j]] = vcat(get_params(p.pdists[j])[2]...)
         end
     end
     @show t_ind

--- a/test/examples/utils/plotting_helpers.jl
+++ b/test/examples/utils/plotting_helpers.jl
@@ -102,7 +102,7 @@ function plot_spectra!(sol, p; file_name = "test_spectra.png", logxrange = (-15,
         plt[i] = plot()
         for j in 1:Ndist
             ind_rng = get_dist_moments_ind_range(p.NProgMoms, j)
-            update_dist_from_moments!(p.pdists[j], moments[t_ind[i], ind_rng])
+            update_dist_from_moments(p.pdists[j], moments[t_ind[i], ind_rng])
             plot!(
                 r,
                 3 * x .^ 2 .* p.pdists[j].(x),
@@ -155,7 +155,7 @@ function plot_params!(sol, p; yscale = :log10, file_name = "box_model.pdf")
     for i in 1:n_dist
         ind_rng = get_dist_moments_ind_range(p.NProgMoms, i)
         for j in 1:size(params)[1]
-            CPD.update_dist_from_moments!(p.pdists[i], moments[j, ind_rng])
+            p.pdists[i] = CPD.update_dist_from_moments(p.pdists[i], moments[j, ind_rng])
             params[j, ind_rng] = vcat(CPD.get_params(p.pdists[i])[2]...)
         end
 
@@ -217,7 +217,7 @@ function print_box_results!(sol, p)
     for i in 1:3
         for j in 1:Ndist
             ind_rng = get_dist_moments_ind_range(p.NProgMoms, j)
-            update_dist_from_moments!(p.pdists[j], moments[t_ind[i], ind_rng])
+            p.pdists[j] = update_dist_from_moments(p.pdists[j], moments[t_ind[i], ind_rng])
             params[i, j, 1:p.NProgMoms[j]] = vcat(CPD.get_params(p.pdists[j])[2]...)
         end
     end

--- a/test/examples/utils/plotting_helpers.jl
+++ b/test/examples/utils/plotting_helpers.jl
@@ -10,7 +10,7 @@ include("./rainshaft_helpers.jl")
   - `dist` - is a particle mass distribution
 Returns the names and values of settable parameters for a dist.
 """
-function get_params(dist::CPD.PrimitiveParticleDistribution{FT <: Real})
+function get_params(dist::CPD.PrimitiveParticleDistribution{FT} where {FT <: Real})
     params = Array{Symbol, 1}(collect(propertynames(dist)))
     values = Array{FT, 1}([getproperty(dist, p) for p in params])
     return params, values

--- a/test/examples/utils/rainshaft_helpers.jl
+++ b/test/examples/utils/rainshaft_helpers.jl
@@ -54,7 +54,7 @@ function make_rainshaft_rhs(coal_type::CoalescenceStyle)
             m_z_normalized = m[i, :] ./ mom_norms
             for (j, dist) in enumerate(p.pdists)
                 ind_rng = get_dist_moments_ind_range(p.NProgMoms, j)
-                update_dist_from_moments!(dist, m_z_normalized[ind_rng])
+                dist = update_dist_from_moments(dist, m_z_normalized[ind_rng])
             end
 
             if all(m_z_normalized .< eps(Float64))

--- a/test/examples/utils/rainshaft_helpers.jl
+++ b/test/examples/utils/rainshaft_helpers.jl
@@ -51,7 +51,7 @@ function make_rainshaft_rhs(coal_type::CoalescenceStyle)
         coal_source = similar(m)
         sedi_flux = similar(m)
         for i in 1:nz
-            m_z_normalized = m[i, :] ./ mom_norms
+            m_z_normalized = tuple(m[i, :] ./ mom_norms...)
             for (j, dist) in enumerate(p.pdists)
                 ind_rng = get_dist_moments_ind_range(p.NProgMoms, j)
                 dist = update_dist_from_moments(dist, m_z_normalized[ind_rng])

--- a/test/unit_tests/test_ParticleDistributions_correctness.jl
+++ b/test/unit_tests/test_ParticleDistributions_correctness.jl
@@ -42,13 +42,13 @@ dist = MonodispersePrimitiveParticleDistribution(1.0, 2.0)
 @test density(dist, 3.1) == 0.0
 
 ## Update params from moments
-dist = dist = update_dist_from_moments(dist, [1.0, 1.0]; param_range = Dict("θ" => (0.1, 0.5)))
+dist = update_dist_from_moments(dist, [1.0, 1.0]; param_range = Dict("θ" => (0.1, 0.5)))
 @test moment(dist, 0.0) ≈ 2.0 rtol = rtol
 @test moment(dist, 1.0) ≈ 1.0 rtol = rtol
-dist = dist = update_dist_from_moments(dist, [1.1, 2.0])
+dist = update_dist_from_moments(dist, [1.1, 2.0])
 @test moment(dist, 0.0) ≈ 1.1 rtol = rtol
 @test moment(dist, 1.0) ≈ 2.0 rtol = rtol
-dist = dist = update_dist_from_moments(dist, [1.1, 0.0])
+dist = update_dist_from_moments(dist, [1.1, 0.0])
 @test moment(dist, 0.0) ≈ 0.0 rtol = rtol
 @test moment(dist, 1.0) ≈ 0.0 rtol = rtol
 

--- a/test/unit_tests/test_ParticleDistributions_correctness.jl
+++ b/test/unit_tests/test_ParticleDistributions_correctness.jl
@@ -4,13 +4,7 @@ using SpecialFunctions: gamma, gamma_inc
 using Cloudy.ParticleDistributions
 
 import Cloudy.ParticleDistributions:
-    get_params,
-    check_moment_consistency,
-    moment_func,
-    density_func,
-    density,
-    get_standard_N_q,
-    integrate_SimpsonEvenFast
+    check_moment_consistency, moment_func, density_func, density, get_standard_N_q
 rtol = 1e-3
 
 # Monodisperse distribution
@@ -22,9 +16,7 @@ dist = MonodispersePrimitiveParticleDistribution(1.0, 1.0)
 
 # Getters and setters
 @test nparams(dist) == 2
-@test get_params(dist) == ([:n, :θ], [1.0, 1.0])
 dist = MonodispersePrimitiveParticleDistribution(1.0, 2.0)
-@test get_params(dist) == ([:n, :θ], [1.0, 2.0])
 @test_throws Exception update_params(dist, [-0.2, 1.1])
 @test_throws Exception update_params(dist, [0.2, -1.1])
 
@@ -62,9 +54,7 @@ dist = ExponentialPrimitiveParticleDistribution(1.0, 1.0)
 
 # Getters and setters
 @test nparams(dist) == 2
-@test get_params(dist) == ([:n, :θ], [1.0, 1.0])
 dist = ExponentialPrimitiveParticleDistribution(1.0, 2.0)
-@test get_params(dist) == ([:n, :θ], [1.0, 2.0])
 @test_throws Exception update_params(dist, [-0.2, 1.1])
 @test_throws Exception update_params(dist, [0.2, -1.1])
 
@@ -107,9 +97,7 @@ dist = GammaPrimitiveParticleDistribution(1.0, 1.0, 2.0)
 
 # Getters and settes
 @test nparams(dist) == 3
-@test get_params(dist) == ([:n, :θ, :k], [1.0, 1.0, 2.0])
 dist = GammaPrimitiveParticleDistribution(1.0, 2.0, 1.0)
-@test get_params(dist) == ([:n, :θ, :k], [1.0, 2.0, 1.0])
 
 # Moments, moments, density
 dist = GammaPrimitiveParticleDistribution(1.0, 1.0, 2.0)
@@ -152,9 +140,7 @@ dist = LognormalPrimitiveParticleDistribution(1.0, 1.0, 2.0)
 
 # Getters and settes
 @test nparams(dist) == 3
-@test get_params(dist) == ([:n, :μ, :σ], [1.0, 1.0, 2.0])
 dist = LognormalPrimitiveParticleDistribution(1.0, 2.0, 1.0)
-@test get_params(dist) == ([:n, :μ, :σ], [1.0, 2.0, 1.0])
 
 # Moments, moments, density
 dist = LognormalPrimitiveParticleDistribution(1.0, 1.0, 2.0)
@@ -163,7 +149,6 @@ dist = LognormalPrimitiveParticleDistribution(1.0, 1.0, 2.0)
 @test moment(dist, 1.0) == exp(3.0)
 @test moment(dist, 2.0) == exp(10.0)
 @test get_moments(dist) == [1.0, exp(3.0), exp(10.0)]
-@test moment_func(dist)([0.0, 1.0, 2.0]) == [1.0, exp(3.0), exp(10.0)]
 @test moment(dist, 0.5) ≈ exp(1.0)
 @test density_func(dist)(exp(1.0)) == 1 / 2.0 / sqrt(2 * π) / exp(1.0)
 @test isnan(density_func(dist)(0.0))

--- a/test/unit_tests/test_ParticleDistributions_correctness.jl
+++ b/test/unit_tests/test_ParticleDistributions_correctness.jl
@@ -23,7 +23,7 @@ dist = MonodispersePrimitiveParticleDistribution(1.0, 1.0)
 # Getters and setters
 @test nparams(dist) == 2
 @test get_params(dist) == ([:n, :θ], [1.0, 1.0])
-dist.n, dist.θ = [1.0, 2.0]
+dist = MonodispersePrimitiveParticleDistribution(1.0, 2.0)
 @test get_params(dist) == ([:n, :θ], [1.0, 2.0])
 @test_throws Exception update_params(dist, [-0.2, 1.1])
 @test_throws Exception update_params(dist, [0.2, -1.1])
@@ -42,13 +42,13 @@ dist = MonodispersePrimitiveParticleDistribution(1.0, 2.0)
 @test density(dist, 3.1) == 0.0
 
 ## Update params from moments
-update_dist_from_moments!(dist, [1.0, 1.0]; param_range = Dict("θ" => (0.1, 0.5)))
+dist = dist = update_dist_from_moments(dist, [1.0, 1.0]; param_range = Dict("θ" => (0.1, 0.5)))
 @test moment(dist, 0.0) ≈ 2.0 rtol = rtol
 @test moment(dist, 1.0) ≈ 1.0 rtol = rtol
-update_dist_from_moments!(dist, [1.1, 2.0])
+dist = dist = update_dist_from_moments(dist, [1.1, 2.0])
 @test moment(dist, 0.0) ≈ 1.1 rtol = rtol
 @test moment(dist, 1.0) ≈ 2.0 rtol = rtol
-update_dist_from_moments!(dist, [1.1, 0.0])
+dist = dist = update_dist_from_moments(dist, [1.1, 0.0])
 @test moment(dist, 0.0) ≈ 0.0 rtol = rtol
 @test moment(dist, 1.0) ≈ 0.0 rtol = rtol
 
@@ -63,7 +63,7 @@ dist = ExponentialPrimitiveParticleDistribution(1.0, 1.0)
 # Getters and setters
 @test nparams(dist) == 2
 @test get_params(dist) == ([:n, :θ], [1.0, 1.0])
-dist.n, dist.θ = [1.0, 2.0]
+dist = ExponentialPrimitiveParticleDistribution(1.0, 2.0)
 @test get_params(dist) == ([:n, :θ], [1.0, 2.0])
 @test_throws Exception update_params(dist, [-0.2, 1.1])
 @test_throws Exception update_params(dist, [0.2, -1.1])
@@ -84,15 +84,15 @@ dist = ExponentialPrimitiveParticleDistribution(1.0, 2.0)
 @test_throws Exception density(dist, -3.1)
 
 ## Update params or dist from moments
-update_dist_from_moments!(dist, [1.1, 2.0])
+dist = update_dist_from_moments(dist, [1.1, 2.0])
 @test normed_density(dist, 0.0) == 0.55
 @test moment(dist, 0.0) ≈ 1.1 rtol = rtol
 @test moment(dist, 1.0) ≈ 2.0 rtol = rtol
 moments = [10.0, 50.0]
-update_dist_from_moments!(dist, moments)
+dist = update_dist_from_moments(dist, moments)
 @test (dist.n, dist.θ) == (10.0, 5.0)
-@test_throws Exception update_dist_from_moments!(dist, [10.0, 50.0, 300.0])
-update_dist_from_moments!(dist, [1.1, 0.0])
+@test_throws Exception update_dist_from_moments(dist, [10.0, 50.0, 300.0])
+dist = update_dist_from_moments(dist, [1.1, 0.0])
 @test moment(dist, 0.0) ≈ 0.0 rtol = rtol
 @test moment(dist, 1.0) ≈ 0.0 rtol = rtol
 
@@ -108,7 +108,7 @@ dist = GammaPrimitiveParticleDistribution(1.0, 1.0, 2.0)
 # Getters and settes
 @test nparams(dist) == 3
 @test get_params(dist) == ([:n, :θ, :k], [1.0, 1.0, 2.0])
-dist.n, dist.θ, dist.k = [1.0, 2.0, 1.0]
+dist = GammaPrimitiveParticleDistribution(1.0, 2.0, 1.0)
 @test get_params(dist) == ([:n, :θ, :k], [1.0, 2.0, 1.0])
 
 # Moments, moments, density
@@ -129,19 +129,20 @@ dist = GammaPrimitiveParticleDistribution(1.0, 1.0, 2.0)
 @test_throws Exception density(dist, -3.1)
 
 # Update params or dist from moments
-update_dist_from_moments!(dist, [1.1, 2.0, 4.1]; param_range = Dict("θ" => (1e-5, 1e5), "k" => (eps(Float64), 5.0)))
+dist =
+    update_dist_from_moments(dist, [1.1, 2.0, 4.1]; param_range = Dict("θ" => (1e-5, 1e5), "k" => (eps(Float64), 5.0)))
 @test normed_density(dist, 1.0) ≈ 0.833 rtol = rtol
 @test moment(dist, 0.0) ≈ 1.726 rtol = rtol
 @test moment(dist, 1.0) ≈ 2.0 rtol = rtol
 @test moment(dist, 2.0) ≈ 2.782 rtol = rtol
-update_dist_from_moments!(dist, [1.1, 2.423, 8.112])
+dist = update_dist_from_moments(dist, [1.1, 2.423, 8.112])
 @test moment(dist, 0.0) ≈ 1.1 rtol = rtol
 @test moment(dist, 1.0) ≈ 2.423 rtol = rtol
 @test moment(dist, 2.0) ≈ 8.112 rtol = rtol
 moments = [10.0, 50.0, 300.0]
-update_dist_from_moments!(dist, moments)
+dist = update_dist_from_moments(dist, moments)
 @test (dist.n, dist.k, dist.θ) == (10.0, 5.0, 1.0)
-@test_throws Exception update_dist_from_moments!(dist, [10.0, 50.0])
+@test_throws Exception update_dist_from_moments(dist, [10.0, 50.0])
 
 # Lognormal distribution
 # Initialization
@@ -153,7 +154,7 @@ dist = LognormalPrimitiveParticleDistribution(1.0, 1.0, 2.0)
 # Getters and settes
 @test nparams(dist) == 3
 @test get_params(dist) == ([:n, :μ, :σ], [1.0, 1.0, 2.0])
-dist.n, dist.μ, dist.σ = [1.0, 2.0, 1.0]
+dist = LognormalPrimitiveParticleDistribution(1.0, 2.0, 1.0)
 @test get_params(dist) == ([:n, :μ, :σ], [1.0, 2.0, 1.0])
 
 # Moments, moments, density
@@ -174,25 +175,26 @@ dist = LognormalPrimitiveParticleDistribution(1.0, 1.0, 2.0)
 @test_throws Exception density(dist, -0.1)
 
 # Update params or dist from moments
-update_dist_from_moments!(dist, [1.1, 2.0, 4.1]; param_range = Dict("μ" => (-1e5, 1e5), "σ" => (eps(Float64), 5.0)))
+dist =
+    update_dist_from_moments(dist, [1.1, 2.0, 4.1]; param_range = Dict("μ" => (-1e5, 1e5), "σ" => (eps(Float64), 5.0)))
 @test normed_density(dist, 1.0) ≈ 0.3450 rtol = rtol
 @test moment(dist, 0.0) ≈ 1.1 rtol = rtol
 @test moment(dist, 1.0) ≈ 2.0 rtol = rtol
 @test moment(dist, 2.0) ≈ 4.1 rtol = rtol
-update_dist_from_moments!(dist, [1.1, 2.423, 8.112])
+dist = update_dist_from_moments(dist, [1.1, 2.423, 8.112])
 @test moment(dist, 0.0) ≈ 1.1 rtol = rtol
 @test moment(dist, 1.0) ≈ 2.423 rtol = rtol
 @test moment(dist, 2.0) ≈ 8.112 rtol = rtol
 moments = [10.0, 50.0, 300.0]
-update_dist_from_moments!(dist, moments)
+dist = update_dist_from_moments(dist, moments)
 @test dist.n ≈ 10.0 rtol = rtol
 @test dist.μ ≈ 1.518 rtol = rtol
 @test dist.σ ≈ 0.427 rtol = rtol
-@test_throws Exception update_dist_from_moments!(dist, [10.0, 50.0])
+@test_throws Exception update_dist_from_moments(dist, [10.0, 50.0])
 
 
 # Moment consistency checks
-update_dist_from_moments!(dist, [1.1, 0.0, 8.112])
+dist = update_dist_from_moments(dist, [1.1, 0.0, 8.112])
 @test moment(dist, 0.0) ≈ 0.0 rtol = rtol
 @test moment(dist, 1.0) ≈ 0.0 rtol = rtol
 @test moment(dist, 2.0) ≈ 0.0 rtol = rtol

--- a/test/unit_tests/test_ParticleDistributions_correctness.jl
+++ b/test/unit_tests/test_ParticleDistributions_correctness.jl
@@ -42,7 +42,7 @@ dist = MonodispersePrimitiveParticleDistribution(1.0, 2.0)
 @test density(dist, 3.1) == 0.0
 
 ## Update params from moments
-dist = update_dist_from_moments(dist, [1.0, 1.0]; param_range = Dict("θ" => (0.1, 0.5)))
+dist = update_dist_from_moments(dist, [1.0, 1.0]; param_range = (; :θ => (0.1, 0.5)))
 @test moment(dist, 0.0) ≈ 2.0 rtol = rtol
 @test moment(dist, 1.0) ≈ 1.0 rtol = rtol
 dist = update_dist_from_moments(dist, [1.1, 2.0])
@@ -129,8 +129,7 @@ dist = GammaPrimitiveParticleDistribution(1.0, 1.0, 2.0)
 @test_throws Exception density(dist, -3.1)
 
 # Update params or dist from moments
-dist =
-    update_dist_from_moments(dist, [1.1, 2.0, 4.1]; param_range = Dict("θ" => (1e-5, 1e5), "k" => (eps(Float64), 5.0)))
+dist = update_dist_from_moments(dist, [1.1, 2.0, 4.1]; param_range = (; :θ => (1e-5, 1e5), :k => (eps(Float64), 5.0)))
 @test normed_density(dist, 1.0) ≈ 0.833 rtol = rtol
 @test moment(dist, 0.0) ≈ 1.726 rtol = rtol
 @test moment(dist, 1.0) ≈ 2.0 rtol = rtol
@@ -175,8 +174,7 @@ dist = LognormalPrimitiveParticleDistribution(1.0, 1.0, 2.0)
 @test_throws Exception density(dist, -0.1)
 
 # Update params or dist from moments
-dist =
-    update_dist_from_moments(dist, [1.1, 2.0, 4.1]; param_range = Dict("μ" => (-1e5, 1e5), "σ" => (eps(Float64), 5.0)))
+dist = update_dist_from_moments(dist, [1.1, 2.0, 4.1]; param_range = (; :μ => (-1e5, 1e5), :σ => (eps(Float64), 5.0)))
 @test normed_density(dist, 1.0) ≈ 0.3450 rtol = rtol
 @test moment(dist, 0.0) ≈ 1.1 rtol = rtol
 @test moment(dist, 1.0) ≈ 2.0 rtol = rtol

--- a/test/unit_tests/test_ParticleDistributions_correctness.jl
+++ b/test/unit_tests/test_ParticleDistributions_correctness.jl
@@ -106,7 +106,7 @@ dist = GammaPrimitiveParticleDistribution(1.0, 1.0, 2.0)
 @test moment(dist, 1.0) == 2.0
 @test moment(dist, 2.0) == 6.0
 @test get_moments(dist) == [1.0, 2.0, 6.0]
-@test moment_func(dist)([0.0, 1.0, 2.0]) == [1.0, 2.0, 6.0]
+@test moment_func(dist).([0.0, 1.0, 2.0]) == [1.0, 2.0, 6.0]
 @test moment(dist, 2 / 3) ≈ gamma(2 + 2 / 3) / gamma(2)
 @test density_func(dist)(0.0) == 0.0
 @test density_func(dist)(3.0) == 3 / gamma(2) * exp(-3)

--- a/test/unit_tests/test_ParticleDistributions_opt.jl
+++ b/test/unit_tests/test_ParticleDistributions_opt.jl
@@ -19,13 +19,13 @@ dist3 = LognormalPrimitiveParticleDistribution(1.0, 2.0, 3.0)
 # moments <-> params
 @test_opt get_moments(dist1)
 moments1 = [10.0, 50.0, 300.0]
-@test_opt update_dist_from_moments!(dist1, moments1)
+@test_opt update_dist_from_moments(dist1, moments1)
 @test_opt get_moments(dist2)
 moments2 = [10.0, 50.0]
-@test_opt update_dist_from_moments!(dist2, moments2)
+@test_opt update_dist_from_moments(dist2, moments2)
 @test_opt get_moments(dist3)
 moments3 = [10.0, 50.0, 300.0]
-@test_opt update_dist_from_moments!(dist3, moments3)
+@test_opt update_dist_from_moments(dist3, moments3)
 
 # moment source helper
 @test_opt moment_source_helper(dist1, 1.0, 0.0, 1.2)

--- a/test/unit_tests/test_ParticleDistributions_opt.jl
+++ b/test/unit_tests/test_ParticleDistributions_opt.jl
@@ -40,8 +40,10 @@ x = collect(range(1.0, 10.0, 100))
 y = x .^ 2
 @test_opt integrate_SimpsonEvenFast(x, y)
 
-# TODO: Move this to perf tests once we have enough to group
-@test 32 >= @allocated update_dist_from_moments(dist1, moments1)
-@test 32 >= @allocated update_dist_from_moments(dist2, moments2)
-@test 32 >= @allocated update_dist_from_moments(dist3, moments3)
-
+# TODO: move these once we make a performance testset
+update_dist_from_moments(dist1, moments1)
+@test 32 == @allocated update_dist_from_moments(dist1, moments1)
+update_dist_from_moments(dist2, moments2)
+@test 32 == @allocated update_dist_from_moments(dist2, moments2)
+update_dist_from_moments(dist3, moments3)
+@test 32 == @allocated update_dist_from_moments(dist3, moments3)

--- a/test/unit_tests/test_ParticleDistributions_opt.jl
+++ b/test/unit_tests/test_ParticleDistributions_opt.jl
@@ -18,13 +18,13 @@ dist3 = LognormalPrimitiveParticleDistribution(1.0, 2.0, 3.0)
 
 # moments <-> params
 @test_opt get_moments(dist1)
-moments1 = [10.0, 50.0, 300.0]
+moments1 = (10.0, 50.0, 300.0)
 @test_opt update_dist_from_moments(dist1, moments1)
 @test_opt get_moments(dist2)
-moments2 = [10.0, 50.0]
+moments2 = (10.0, 50.0)
 @test_opt update_dist_from_moments(dist2, moments2)
 @test_opt get_moments(dist3)
-moments3 = [10.0, 50.0, 300.0]
+moments3 = (10.0, 50.0, 300.0)
 @test_opt update_dist_from_moments(dist3, moments3)
 
 # moment source helper
@@ -41,9 +41,17 @@ y = x .^ 2
 @test_opt integrate_SimpsonEvenFast(x, y)
 
 # TODO: move these once we make a performance testset
-update_dist_from_moments(dist1, moments1)
-@test 32 == @allocated update_dist_from_moments(dist1, moments1)
-update_dist_from_moments(dist2, moments2)
-@test 32 == @allocated update_dist_from_moments(dist2, moments2)
-update_dist_from_moments(dist3, moments3)
-@test 32 == @allocated update_dist_from_moments(dist3, moments3)
+
+pdists = [
+    ExponentialPrimitiveParticleDistribution(10.0, 1.0),
+    GammaPrimitiveParticleDistribution(5.0, 10.0, 2.0),
+    MonodispersePrimitiveParticleDistribution(1.0, 0.5),
+    LognormalPrimitiveParticleDistribution(1.0, 1.0, 2.0),
+]
+
+moments = [(1.1, 2.0), (1.1, 2.0, 4.1), (1.0, 1.0), (1.1, 2.0, 4.1)]
+
+for (dist, mom) in zip(pdists, moments)
+    update_dist_from_moments(dist, mom)
+    @test 32 == @allocated update_dist_from_moments(dist, mom)
+end

--- a/test/unit_tests/test_ParticleDistributions_opt.jl
+++ b/test/unit_tests/test_ParticleDistributions_opt.jl
@@ -39,3 +39,8 @@ pdists = (dist1, dist2, dist3)
 x = collect(range(1.0, 10.0, 100))
 y = x .^ 2
 @test_opt integrate_SimpsonEvenFast(x, y)
+
+# Move this to perf tests once we have enough to group
+@test 32 >= @allocated update_dist_from_moments(dist1, moments1)
+@test 32 >= @allocated update_dist_from_moments(dist2, moments2)
+@test 32 >= @allocated update_dist_from_moments(dist3, moments3)

--- a/test/unit_tests/test_ParticleDistributions_opt.jl
+++ b/test/unit_tests/test_ParticleDistributions_opt.jl
@@ -40,7 +40,8 @@ x = collect(range(1.0, 10.0, 100))
 y = x .^ 2
 @test_opt integrate_SimpsonEvenFast(x, y)
 
-# Move this to perf tests once we have enough to group
+# TODO: Move this to perf tests once we have enough to group
 @test 32 >= @allocated update_dist_from_moments(dist1, moments1)
 @test 32 >= @allocated update_dist_from_moments(dist2, moments2)
 @test 32 >= @allocated update_dist_from_moments(dist3, moments3)
+

--- a/test/unit_tests/test_Sources_correctness.jl
+++ b/test/unit_tests/test_Sources_correctness.jl
@@ -48,7 +48,7 @@ function sm1916(n_steps, δt; is_kernel_function = true, is_one_mode = true)
 
     # Euler steps
     for i in 1:n_steps
-        dist = update_dist_from_moments(dist[1], mom[1:2])
+        dist[1] = update_dist_from_moments(dist[1], mom[1:2])
         update_coal_ints!(AnalyticalCoalStyle(), dist, coal_data)
         dmom = coal_data.coal_ints
         mom += δt * dmom

--- a/test/unit_tests/test_Sources_correctness.jl
+++ b/test/unit_tests/test_Sources_correctness.jl
@@ -42,16 +42,16 @@ function sm1916(n_steps, δt; is_kernel_function = true, is_one_mode = true)
     ker = (is_kernel_function == true) ? CoalescenceTensor(kernel_func, 0, 100.0) : CoalescenceTensor([1.0])
 
     # Initial condition
-    mom = [1.0, 2.0]
+    mom = (1.0, 2.0)
     dist = [ExponentialPrimitiveParticleDistribution(1.0, 1.0)]
     coal_data = initialize_coalescence_data(AnalyticalCoalStyle(), ker, [nparams(dist[1])])
 
     # Euler steps
     for i in 1:n_steps
-        dist[1] = update_dist_from_moments(dist[1], mom[1:2])
+        dist[1] = update_dist_from_moments(dist[1], mom)
         update_coal_ints!(AnalyticalCoalStyle(), dist, coal_data)
         dmom = coal_data.coal_ints
-        mom += δt * dmom
+        mom = tuple(δt * dmom .+ mom...)
     end
 
     return mom
@@ -68,8 +68,8 @@ rtol = 1e-3
 # Run tests
 for i in 0:n_steps
     t = δt * i
-    @test sm1916(n_steps, δt) ≈ Array{FT}([sm1916_ana(t, 1, 1), 2.0]) rtol = rtol
-    @test sm1916(n_steps, δt, is_kernel_function = false) ≈ Array{FT}([sm1916_ana(t, 1, 1), 2.0]) rtol = rtol
+    @test all(isapprox.(sm1916(n_steps, δt), (sm1916_ana(t, 1, 1), 2.0); rtol))
+    @test all(isapprox.(sm1916(n_steps, δt; is_kernel_function = false), (sm1916_ana(t, 1, 1), 2.0); rtol))
 end
 
 # Test Exponential + Gamma

--- a/test/unit_tests/test_Sources_correctness.jl
+++ b/test/unit_tests/test_Sources_correctness.jl
@@ -48,7 +48,7 @@ function sm1916(n_steps, δt; is_kernel_function = true, is_one_mode = true)
 
     # Euler steps
     for i in 1:n_steps
-        update_dist_from_moments!(dist[1], mom[1:2])
+        dist = update_dist_from_moments(dist[1], mom[1:2])
         update_coal_ints!(AnalyticalCoalStyle(), dist, coal_data)
         dmom = coal_data.coal_ints
         mom += δt * dmom


### PR DESCRIPTION
Content
- Changes to `update_dist_from_moments!`
  - Now returns a new dist struct instead of modifying the input. 
  - Renamed `update_dist_from_moments!` to `update_dist_from_moments`, since it is not modifying data
  - Convert argument `param_range` from a Dict to a NamedTuple - this reduces allocations by a lot
- Update CI to 1.10, use shared depot for CI
- Added allocation tests for `update_dist_from_moments`

More to do on the particledistributions:
- Make the moments Tuples with fixed size